### PR TITLE
Fix vertical spacing of the paging dots

### DIFF
--- a/Sources/SharedMobileUI/Views/PagedNavigationBar.swift
+++ b/Sources/SharedMobileUI/Views/PagedNavigationBar.swift
@@ -20,8 +20,7 @@ public struct PagedNavigationBar : View {
             
             if self.showsDots, viewModel.pageCount > 0, !viewModel.progressHidden {
                 PagingDotsView()
-                    .padding(.vertical, (viewModel.forwardButtonText != nil) || viewModel.pageCount > 7 ?
-                                8.0 : 0.0)
+                    .padding(.vertical, 8)
             }
                 
             HStack {


### PR DESCRIPTION
The original design did not have “Next” in the forward button and in that design, the spacing was intentionally *very* tight. This results in a weird overlap on an iPhone SE.